### PR TITLE
feat: Add optional text-to-speech output for sprayed words

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,6 +94,11 @@
               <option value="800">800 wpm</option>
             </select>
           </div>
+          <div class="col-md-4"> <!-- Adjusted column size for checkbox -->
+            <label class="checkbox-inline control-label">
+              <input type="checkbox" id="audio-enable" name="audio-enable"> Enable Audio
+            </label>
+          </div>
         </div>
 
         <!-- Button (Double) -->
@@ -154,6 +159,13 @@
           $('#decrease-font').click(function(event) {
             sprayReader.decreaseFontSize();
             event.preventDefault();
+          });
+
+          $('#audio-enable').change(function(event) {
+            sprayReader.isAudioEnabled = $(this).is(':checked');
+            if (!sprayReader.isAudioEnabled && sprayReader.speechSynthesis && sprayReader.speechSynthesis.speaking) {
+              sprayReader.speechSynthesis.cancel();
+            }
           });
         });
     </script>

--- a/docs/js/spray-reader.js
+++ b/docs/js/spray-reader.js
@@ -4,6 +4,8 @@ var SprayReader = function(container){
   var initialFontSizeCss = this.container.css('font-size');
   this.fontSize = parseFloat(initialFontSizeCss) || 3; // Default to 3 if parsing fails
   this.guideElements = $('#guide_top, #guide_bottom, #notch');
+  this.speechSynthesis = window.speechSynthesis;
+  this.isAudioEnabled = false;
 };
 SprayReader.prototype = {
   wpm: null,
@@ -79,6 +81,9 @@ SprayReader.prototype = {
     for(var i = 0; i < this.timers.length; i++) {
       clearTimeout(this.timers[i]);
     }
+    if (this.speechSynthesis && this.speechSynthesis.speaking) {
+      this.speechSynthesis.cancel();
+    }
   },
 
   displayWordAndIncrement: function() {
@@ -86,8 +91,18 @@ SprayReader.prototype = {
 
     this.container.html(pivotedWord);
 
+    if (this.isAudioEnabled && this.speechSynthesis) {
+      var wordToSpeak = this.words[this.wordIdx];
+      // Basic cleaning: remove punctuation that might be harsh in speech
+      wordToSpeak = wordToSpeak.replace(/[•:,.;?!()-]/g, '');
+      if (wordToSpeak.trim().length > 0) {
+        var utterance = new SpeechSynthesisUtterance(wordToSpeak);
+        this.speechSynthesis.speak(utterance);
+      }
+    }
+
     this.wordIdx++;
-    if (thisObj.wordIdx >= thisObj.words.length) {
+    if (this.wordIdx >= this.words.length) { // Changed thisObj to this
       this.wordIdx = 0;
       this.stop();
     }


### PR DESCRIPTION
This commit introduces an optional audio output feature to the spray reader. Users can now enable a checkbox to have each word read aloud as it is displayed.

The implementation uses the browser's built-in SpeechSynthesis API. Modifications include:
- Added an 'Enable Audio' checkbox to `docs/index.html`.
- Updated `docs/js/spray-reader.js` to initialize SpeechSynthesis, speak words when audio is enabled, and cancel speech when stopped or disabled.
- Added an event listener in `docs/index.html` to control the audio feature via the checkbox.