### PR TITLE
fix: Synchronize speech rate with WPM settings

### DIFF
--- a/docs/js/spray-reader.js
+++ b/docs/js/spray-reader.js
@@ -97,6 +97,11 @@ SprayReader.prototype = {
       wordToSpeak = wordToSpeak.replace(/[•:,.;?!()-]/g, '');
       if (wordToSpeak.trim().length > 0) {
         var utterance = new SpeechSynthesisUtterance(wordToSpeak);
+        // Calculate speech rate based on WPM
+        // Baseline: 150 WPM = rate 1.0
+        // Clamp rate between 0.5 and 4 for quality and compatibility
+        var calculatedRate = this.wpm / 150;
+        utterance.rate = Math.max(0.5, Math.min(calculatedRate, 4));
         this.speechSynthesis.speak(utterance);
       }
     }


### PR DESCRIPTION
This commit adjusts the text-to-speech audio output to scale the speech rate according to the selected Words Per Minute (WPM).

Previously, the speech rate was constant, leading to a mismatch between the visual display of words and the audio output at higher WPM settings.

The `SpeechSynthesisUtterance.rate` property is now dynamically calculated based on the current WPM, ensuring that the audio playback speed matches the speed at which words are displayed. The rate is clamped to a reasonable range (0.5 to 4.0) to maintain intelligibility and browser compatibility.

This provides a more synchronized and natural user experience when the audio feature is enabled.