### PR TITLE
Fix: Correct font size adjustment logic

### DIFF
--- a/docs/js/spray-reader.js
+++ b/docs/js/spray-reader.js
@@ -1,8 +1,7 @@
 var SprayReader = function(container){
   this.container = $(container);
-  // Get initial font size from CSS (e.g., "3vw") and parse the number
-  var initialFontSizeCss = this.container.css('font-size');
-  this.fontSize = parseFloat(initialFontSizeCss) || 3; // Default to 3 if parsing fails
+  // Initial font size is 3vw as defined in spray-style.css
+  this.fontSize = 3;
   this.guideElements = $('#guide_top, #guide_bottom, #notch');
   this.speechSynthesis = window.speechSynthesis;
   this.isAudioEnabled = false;


### PR DESCRIPTION
The initial font size was being parsed as a pixel value from computed styles (e.g., 16px), but then treated as a VW unit in the increase/decrease functions. This caused incorrect behavior, such as the font size jumping to a very large VW value (e.g., 15.5vw) on the first decrease, and the increase button not working if the parsed pixel value was already numerically greater than the VW cap (4).

This commit changes the SprayReader constructor to initialize `this.fontSize` directly to the numeric part of its intended initial `vw` value (3), as defined in the CSS. This ensures that subsequent adjustments operate on the correct unit and scale.