### PR TITLE
feat: Add word counter to spray container

### DIFF
--- a/docs/css/spray-style.css
+++ b/docs/css/spray-style.css
@@ -101,3 +101,8 @@
 #font-size-controls button {
     margin: 0 5px;
 }
+
+#word_counter {
+    margin-top: 10px;
+    color: #555;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
         <div id="guide_bottom">
             ——————————————————————————
         </div>
+        <div id="word_counter"></div>
         <div id="font-size-controls">
           <button id="decrease-font" class="btn btn-default btn-sm">-</button>
           <button id="increase-font" class="btn btn-default btn-sm">+</button>

--- a/docs/js/spray-reader.js
+++ b/docs/js/spray-reader.js
@@ -1,6 +1,7 @@
 var SprayReader = function(containerSelector){ 
   this.container = $('#spray_container');
-  this.sprayResultElement = $(containerSelector); 
+  this.sprayResultElement = $(containerSelector);
+  this.wordCounterElement = $('#word_counter');
   this.fontSize = 3; 
   this.guideElements = $('#guide_top, #guide_bottom, #notch');
   this.speechSynthesis = window.speechSynthesis;
@@ -12,6 +13,7 @@ SprayReader.prototype = {
   wordIdx: null,
   input: null,
   words: null,
+  totalWordCount: 0,
   isRunning: false,
   timers: [],
 
@@ -56,7 +58,9 @@ SprayReader.prototype = {
     }
 
     this.words = tmpWords.slice(0);
+    this.totalWordCount = this.words.length;
     this.wordIdx = 0;
+    this.wordCounterElement.text("0 / " + this.totalWordCount);
   },
 
   setWpm: function(wpm) {
@@ -105,6 +109,9 @@ SprayReader.prototype = {
       this.speechSynthesis.cancel();
     }
     // No need to reset wordIdx here, as starting again should handle it or setInput.
+    if (this.wordCounterElement) {
+        this.wordCounterElement.text("0 / " + this.totalWordCount);
+    }
   },
 
   displayWordAndIncrement: function() {
@@ -112,6 +119,8 @@ SprayReader.prototype = {
       this.stop();
       return;
     }
+
+    this.wordCounterElement.text((this.wordIdx + 1) + " / " + this.totalWordCount);
 
     // Clear any existing timers before displaying the next word
     // This is important if displayWordAndIncrement is called ahead of schedule (e.g. by a premature fallback)


### PR DESCRIPTION
This feature adds a word counter to the spray reader interface. The counter displays the current word number and the total word count in the format "word number / total word count".

The implementation includes:
- A new div element with id 'word_counter' in `index.html`.
- JavaScript logic in `spray-reader.js` to:
  - Initialize the counter on text input.
  - Update the counter as each word is displayed.
  - Reset the counter when the spray reader is stopped.
- CSS styling for the new word counter element in `spray-style.css`.