### PR TITLE
Fix: Correct word highlighting and set container background

### DIFF
--- a/docs/css/spray-style.css
+++ b/docs/css/spray-style.css
@@ -110,13 +110,26 @@
 
 #input-text-container {
     position: relative;
+    background-color: #fff;
+}
+
+#input-text, #input-text-highlighter {
+    /* Shared styles for alignment */
+    font-family: monospace, sans-serif;
+    font-size: 13px;
+    line-height: 1.42857143;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    padding: 6px 12px;
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
 }
 
 #input-text-highlighter {
     position: absolute;
     top: 0;
     left: 0;
-    padding: 6px 12px;
     width: 100%;
     height: 100%;
     border-color: transparent;
@@ -124,20 +137,14 @@
     color: transparent;
     -webkit-text-fill-color: transparent;
     z-index: 1;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-family: monospace, sans-serif;
-    font-size: 13px;
-    line-height: 1.42857143;
-    -webkit-box-sizing: border-box;
-       -moz-box-sizing: border-box;
-            box-sizing: border-box;
 }
 
 #input-text {
     position: relative;
     z-index: 2;
     background-color: transparent;
+    width: 100%;
+    resize: vertical;
 }
 
 .highlight {


### PR DESCRIPTION
This commit addresses two issues:
1. The `input-text-container` now has a white background as requested.
2. The word highlighting feature in the `input-text-container` is now working correctly. This was achieved by synchronizing the CSS styles (font, padding, etc.) between the `textarea` and the highlighter `div` to ensure proper alignment.